### PR TITLE
Clippy is installed by default

### DIFF
--- a/recipes/quickstart.md
+++ b/recipes/quickstart.md
@@ -71,7 +71,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy


### PR DESCRIPTION
We can remove `rustup component add clippy` from the example because it's installed by default