### PR TITLE
add workspace and all-targets to recipes

### DIFF
--- a/recipes/matrix.md
+++ b/recipes/matrix.md
@@ -45,10 +45,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --workspace
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace
 
       - uses: actions-rs/cargo@v1
         with:
@@ -58,7 +60,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --all-targets -- -D warnings
 ```
 
 ## Can I tune it?

--- a/recipes/msrv.md
+++ b/recipes/msrv.md
@@ -37,6 +37,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --workspace --all-targets
 
   test:
     name: Test Suite
@@ -56,6 +57,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace --all-targets
 
   fmt:
     name: Rustfmt
@@ -97,7 +99,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --all-targets -- -D warnings
 ```
 
 ## Can I tune it?

--- a/recipes/nightly-lints.md
+++ b/recipes/nightly-lints.md
@@ -38,7 +38,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --all-targets -- -D warnings
 ```
 
 ## Can I tune it?

--- a/recipes/quickstart.md
+++ b/recipes/quickstart.md
@@ -34,6 +34,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --workspace --all-targets
 
   test:
     name: Test Suite
@@ -48,6 +49,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace
 
   fmt:
     name: Rustfmt
@@ -79,7 +81,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --all-targets -- -D warnings
 ```
 
 ## Can I tune it?


### PR DESCRIPTION
rationale: if someone just copies and pastes the recipes over, the --workspace and --all-targets should do no harm but also will not cause surprises when user adds an subcrate. The user might not want to have all of their test code ran through clippy, so they might choose to just use --examples --bins --benches for example. building and testing the workspace doesn't seem to cause issues in crates without a workspace.

this brings the configuration to more in line with `cargo fmt --all ...`, which does work on all of the workspace.

I haven't used the auditor one so can't comment if it should have some --workspace switch as well though it's configuration doesn't seem to hint at it.